### PR TITLE
PDZInfo - opravy

### DIFF
--- a/src/DTO/PDZRecord.php
+++ b/src/DTO/PDZRecord.php
@@ -45,8 +45,8 @@ class PDZRecord
 	#[Serializer\Type('string')]
 	#[Serializer\SerializedName('p:ODZIdent')]
 	#[Serializer\XmlElement(cdata: false)]
-	#[Assert\NotBlank(allowNull: false)]
-	protected string $ident;
+	#[Assert\NotBlank(allowNull: true)]
+	protected ?string $ident;
 
 	public function getType(): string
 	{
@@ -103,12 +103,12 @@ class PDZRecord
 		return $this;
 	}
 
-	public function getIdent(): string
+	public function getIdent(): ?string
 	{
 		return $this->ident;
 	}
 
-	public function setIdent(string $ident): PDZRecord
+	public function setIdent(?string $ident): PDZRecord
 	{
 		$this->ident = $ident;
 		return $this;

--- a/src/DTO/Response/PDZInfo.php
+++ b/src/DTO/Response/PDZInfo.php
@@ -19,8 +19,9 @@ class PDZInfo extends IResponse
 	 * @var PDZRecord[]
 	 */
 	#[Serializer\Type('array<TomasKulhanek\CzechDataBox\DTO\PDZRecord>')]
-	#[Serializer\XmlList(entry: 'dbPDZRecord', inline: false)]
-	#[Serializer\SerializedName('p:dbPDZRecords')]
+	#[Serializer\XmlList(entry: 'dbPDZRecord', inline: false, namespace: 'http://isds.czechpoint.cz/v20')]
+	#[Serializer\SerializedName('dbPDZRecords')]
+	#[Serializer\XmlElement(cdata: false, namespace: 'http://isds.czechpoint.cz/v20')]
 	#[Assert\All([
 		new Assert\Type(type: PDZRecord::class)
 	])]


### PR DESCRIPTION
1) ODZIdent u dbPDZRecord v PDZInfo muže být null, uváděn je pouze u typu "O", tj. u odpovědních PDZ

2) Oprava parsování, kdy pole PDZRecord bylo jinak vždy prázdné

![Snímek obrazovky 2023-09-03 230459](https://github.com/tomas-kulhanek/czech-data-box/assets/4020490/bc1c38e2-c612-4217-8dfa-a1e3edb4d06f)
