### PR TITLE
feat: switch ISDS endpoints to datovka.gov.cz domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PHP knihovna pro komunikaci s Informačním systémem datových schránek (ISDS) Ministerstva vnitra
+# PHP knihovna pro komunikaci s Informačním systémem datových schránek (ISDS) Digitální a informační agentury
 
 ![DEV branch workflows](https://github.com/tomas-kulhanek/czech-data-box/actions/workflows/main.yml/badge.svg)
 [![Latest Stable Version](https://poser.pugx.org/tomas-kulhanek/czech-data-box/v/stable)](https://packagist.org/packages/tomas-kulhanek/czech-data-box)
@@ -7,7 +7,7 @@
 [![License](https://poser.pugx.org/tomas-kulhanek/czech-data-box/license)](https://packagist.org/packages/tomas-kulhanek/czech-data-box)
 
 
-⚠ **POZOR!!** Pokud implementujete napojení na ISDS, je potřeba aby jste se řídili dle [PROVOZNÍHO ŘÁDU](https://info.mojedatovaschranka.cz/info/cs/80.html)⚠
+⚠ **POZOR!!** Pokud implementujete napojení na ISDS, je potřeba aby jste se řídili dle [PROVOZNÍHO ŘÁDU](https://datovka.gov.cz/info/cs/80.html)⚠
 ## Instalace
 
 ### Composer
@@ -29,7 +29,7 @@ composer require tomas-kulhanek/czech-data-box symfony/http-client
 V případě využívání vlastního http klienta, stačí implementovat rozhraní `TomasKulhanek\CzechDataBox\Provider\ClientProviderInterface` a předat ho do konstruktoru třídy `TomasKulhanek\CzechDataBox\Connector`. Samozřejmostí je třeba zajistit správné nastavení hlaviček nebo SSL klientských certifikátů.
 
 ## Popis
-Tato knihovna slouží k základní komunikaci s Informačním systémem datových scrhánek [ISDS](https://mojedatovaschranka.cz) nebo [ISDS test](https://czebox.cz)
+Tato knihovna slouží k základní komunikaci s Informačním systémem datových schránek [ISDS](https://www.datovka.gov.cz) nebo [ISDS test](https://datovka-test.gov.cz)
 
 ## Základní použití
 Pro každou operaci je potřebné zadat přístupové údaje
@@ -72,9 +72,10 @@ V případě že potřebujete poradit, nebo při implementaci Vám třída zobra
 Základní pomoc je poskytována zcela zdarma pomocí Issues.
 
 ## Odkazy
-- Produkční ISDS - https://mojedatoveschranky.cz
-- Testovací ISDS - https://czebox.cz
-- Provozní řád ISDS - https://info.mojedatovaschranka.cz/info/cs/80.html
+- Produkční ISDS - https://www.datovka.gov.cz
+- Testovací ISDS - https://datovka-test.gov.cz
+- Provozní řád ISDS - https://datovka.gov.cz/info/cs/80.html
+- Změny pro dodavatele aplikací - https://datovka.gov.cz/info/cs/74.html
 - Poradna - https://poradnaisds.cz/
 
 ## Žádosti o zřízení datové schránky
@@ -83,4 +84,4 @@ Základní pomoc je poskytována zcela zdarma pomocí Issues.
 - ostatní - [odkaz](https://www.datoveschranky.info/documents/1744842/1746063/zadost_zrizeni_ds.zfo/42ee7c26-16dd-427f-94c8-319453efdae4)
 
 ### Testovací prostředí
-Zřízení testovací schránky v prostředí czecbox.cz je možné skrze formulář na produkčním portalu www.mojedatoveschranky.cz po přihlášení v nastavení
+Zřízení testovací schránky v prostředí datovka-test.gov.cz je možné skrze formulář na produkčním portálu www.datovka.gov.cz po přihlášení v nastavení

--- a/src/DTO/Delivery.php
+++ b/src/DTO/Delivery.php
@@ -54,7 +54,6 @@ class Delivery
     #[Assert\All([
         new Assert\Type(type: DataMessageEvent::class)
     ])]
-    #[Assert\All()]
     protected array $events = [];
 
     public function getHash(): Hash

--- a/src/Provider/EndpointProvider.php
+++ b/src/Provider/EndpointProvider.php
@@ -13,9 +13,9 @@ class EndpointProvider
     private function getServiceDomain(bool $isProduction): string
     {
         if ($isProduction) {
-            return 'mojedatovaschranka.cz';
+            return 'datovka.gov.cz';
         }
-        return 'czebox.cz';
+        return 'datovka-test.gov.cz';
     }
 
     private function getServiceUrl(ServiceTypeEnum $serviceType): string

--- a/tests/Unit/EndpointProviderTest.php
+++ b/tests/Unit/EndpointProviderTest.php
@@ -19,21 +19,21 @@ class EndpointProviderTest extends TestCase
         $account->setLoginType(LoginTypeEnum::NAME_PASSWORD);
 
         $endpointProvider = new EndpointProvider();
-        self::assertSame('https://ws1.czebox.cz/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
+        self::assertSame('https://ws1.datovka-test.gov.cz/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
         $account->setProduction(true);
-        self::assertSame('https://ws1.mojedatovaschranka.cz/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
+        self::assertSame('https://ws1.datovka.gov.cz/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
 
         $account->setProduction(false);
         $account->setLoginType(LoginTypeEnum::SPIS_CERT);
-        self::assertSame('https://ws1c.czebox.cz/cert/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
+        self::assertSame('https://ws1c.datovka-test.gov.cz/cert/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
         $account->setProduction(true);
-        self::assertSame('https://ws1c.mojedatovaschranka.cz/cert/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
+        self::assertSame('https://ws1c.datovka.gov.cz/cert/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
 
         $account->setLoginType(LoginTypeEnum::CERT_LOGIN_NAME_PASSWORD);
         $account->setProduction(false);
-        self::assertSame('https://ws1c.czebox.cz/certds/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
+        self::assertSame('https://ws1c.datovka-test.gov.cz/certds/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
         $account->setProduction(true);
-        self::assertSame('https://ws1c.mojedatovaschranka.cz/certds/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
+        self::assertSame('https://ws1c.datovka.gov.cz/certds/DS/dx', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::INFO));
     }
 
     public function testSupplementaryServices(): void
@@ -43,21 +43,21 @@ class EndpointProviderTest extends TestCase
         $account->setLoginType(LoginTypeEnum::NAME_PASSWORD);
 
         $endpointProvider = new EndpointProvider();
-        self::assertSame('https://ws1.czebox.cz/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
+        self::assertSame('https://ws1.datovka-test.gov.cz/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
         $account->setProduction(true);
-        self::assertSame('https://ws1.mojedatovaschranka.cz/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
+        self::assertSame('https://ws1.datovka.gov.cz/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
 
         $account->setProduction(false);
         $account->setLoginType(LoginTypeEnum::SPIS_CERT);
-        self::assertSame('https://ws1c.czebox.cz/cert/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
+        self::assertSame('https://ws1c.datovka-test.gov.cz/cert/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
         $account->setProduction(true);
-        self::assertSame('https://ws1c.mojedatovaschranka.cz/cert/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
+        self::assertSame('https://ws1c.datovka.gov.cz/cert/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
 
         $account->setLoginType(LoginTypeEnum::CERT_LOGIN_NAME_PASSWORD);
         $account->setProduction(false);
-        self::assertSame('https://ws1c.czebox.cz/certds/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
+        self::assertSame('https://ws1c.datovka-test.gov.cz/certds/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
         $account->setProduction(true);
-        self::assertSame('https://ws1c.mojedatovaschranka.cz/certds/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
+        self::assertSame('https://ws1c.datovka.gov.cz/certds/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SUPPLEMENTARY));
     }
 
     public function testAccessServices(): void
@@ -67,21 +67,21 @@ class EndpointProviderTest extends TestCase
         $account->setLoginType(LoginTypeEnum::NAME_PASSWORD);
 
         $endpointProvider = new EndpointProvider();
-        self::assertSame('https://ws1.czebox.cz/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
+        self::assertSame('https://ws1.datovka-test.gov.cz/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
         $account->setProduction(true);
-        self::assertSame('https://ws1.mojedatovaschranka.cz/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
+        self::assertSame('https://ws1.datovka.gov.cz/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
 
         $account->setProduction(false);
         $account->setLoginType(LoginTypeEnum::SPIS_CERT);
-        self::assertSame('https://ws1c.czebox.cz/cert/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
+        self::assertSame('https://ws1c.datovka-test.gov.cz/cert/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
         $account->setProduction(true);
-        self::assertSame('https://ws1c.mojedatovaschranka.cz/cert/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
+        self::assertSame('https://ws1c.datovka.gov.cz/cert/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
 
         $account->setLoginType(LoginTypeEnum::CERT_LOGIN_NAME_PASSWORD);
         $account->setProduction(false);
-        self::assertSame('https://ws1c.czebox.cz/certds/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
+        self::assertSame('https://ws1c.datovka-test.gov.cz/certds/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
         $account->setProduction(true);
-        self::assertSame('https://ws1c.mojedatovaschranka.cz/certds/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
+        self::assertSame('https://ws1c.datovka.gov.cz/certds/DS/DsManage', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::ACCESS));
     }
 
     public function testSearchServices(): void
@@ -91,20 +91,20 @@ class EndpointProviderTest extends TestCase
         $account->setLoginType(LoginTypeEnum::NAME_PASSWORD);
 
         $endpointProvider = new EndpointProvider();
-        self::assertSame('https://ws1.czebox.cz/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
+        self::assertSame('https://ws1.datovka-test.gov.cz/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
         $account->setProduction(true);
-        self::assertSame('https://ws1.mojedatovaschranka.cz/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
+        self::assertSame('https://ws1.datovka.gov.cz/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
 
         $account->setProduction(false);
         $account->setLoginType(LoginTypeEnum::SPIS_CERT);
-        self::assertSame('https://ws1c.czebox.cz/cert/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
+        self::assertSame('https://ws1c.datovka-test.gov.cz/cert/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
         $account->setProduction(true);
-        self::assertSame('https://ws1c.mojedatovaschranka.cz/cert/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
+        self::assertSame('https://ws1c.datovka.gov.cz/cert/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
 
         $account->setLoginType(LoginTypeEnum::CERT_LOGIN_NAME_PASSWORD);
         $account->setProduction(false);
-        self::assertSame('https://ws1c.czebox.cz/certds/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
+        self::assertSame('https://ws1c.datovka-test.gov.cz/certds/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
         $account->setProduction(true);
-        self::assertSame('https://ws1c.mojedatovaschranka.cz/certds/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
+        self::assertSame('https://ws1c.datovka.gov.cz/certds/DS/df', $endpointProvider->getServiceLocation($account, ServiceTypeEnum::SEARCH));
     }
 }


### PR DESCRIPTION
## Souhrn

Nový Provozní řád ISDS platný od **26. 06. 2026** (WSDL 3.11) přesouvá webové služby na doménu jednotné státní domény gov.cz:

- produkce: `mojedatovaschranka.cz` → **`datovka.gov.cz`**
- veřejný test: `czebox.cz` → **`datovka-test.gov.cz`**

URL cesty (`/DS/dz`, `/cert/`, `/certds/`, `/hspis/`…) se nemění, jen doména. Staré domény běží souběžně **minimálně do 31. 12. 2027** ([oficiální oznámení DIA](https://datovka.gov.cz/info/cs/2063.html)), takže jde o nedestruktivní změnu výchozích adres.

## Změny

- `EndpointProvider`: nové výchozí domény pro produkci i test
- `EndpointProviderTest`: aktualizace všech 24 assertů
- `README.md`: odkazy na nový portál, testovací prostředí a provozní řád; správcem ISDS je DIA (dříve MV ČR); oprava překlepů v doménách
- `DTO/Delivery.php`: odstraněn duplicitní prázdný `#[Assert\All()]` atribut, který shazoval phpstan (atribut není repeatable) — oprava nutná pro zelenou CI

## Ověření

- `ws1.datovka.gov.cz/DS/dx` a `ws1.datovka-test.gov.cz/DS/dx` odpovídají HTTP 401 (služba běží, vyžaduje autentizaci) — ověřeno 04. 07. 2026
- phpunit (16 testů, 4133 assertů), phpstan, rector i phpcs zelené

🤖 Generated with [Claude Code](https://claude.com/claude-code)