### PR TITLE
fix: align DTO XML mapping with ISDS XSD definitions

### DIFF
--- a/src/DTO/DataBoxResult.php
+++ b/src/DTO/DataBoxResult.php
@@ -44,11 +44,11 @@ class DataBoxResult
     #[Serializer\SkipWhenEmpty]
     protected ?string $dataBoxIco = null;
 
-    #[Serializer\Type('bool')]
+    #[Serializer\Type('string')]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
-    #[Serializer\SerializedName('dbEffectiveOVM')]
+    #[Serializer\SerializedName('dbIdOVM')]
     #[Serializer\SkipWhenEmpty]
-    protected ?bool $dataBoxEffectiveOvm = null;
+    protected ?string $dataBoxIdOvm = null;
 
     #[Serializer\Type('string')]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
@@ -111,14 +111,14 @@ class DataBoxResult
         return $this;
     }
 
-    public function getDataBoxEffectiveOvm(): ?bool
+    public function getDataBoxIdOvm(): ?string
     {
-        return $this->dataBoxEffectiveOvm;
+        return $this->dataBoxIdOvm;
     }
 
-    public function setDataBoxEffectiveOvm(?bool $dataBoxEffectiveOvm): DataBoxResult
+    public function setDataBoxIdOvm(?string $dataBoxIdOvm): DataBoxResult
     {
-        $this->dataBoxEffectiveOvm = $dataBoxEffectiveOvm;
+        $this->dataBoxIdOvm = $dataBoxIdOvm;
         return $this;
     }
 

--- a/src/DTO/DataMessageEvent.php
+++ b/src/DTO/DataMessageEvent.php
@@ -14,8 +14,8 @@ class DataMessageEvent
 {
     #[Serializer\Type("DateTimeImmutable<'Y-m-d\\TH:i:s.uP','Europe/Prague'>")]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
-    #[Serializer\SerializedName('dnEventTime')]
-    protected DateTimeImmutable $time;
+    #[Serializer\SerializedName('dmEventTime')]
+    protected ?DateTimeImmutable $time = null;
 
     #[Serializer\Type('string')]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
@@ -23,7 +23,7 @@ class DataMessageEvent
     #[Assert\NotBlank(allowNull: false)]
     protected string $description;
 
-    public function getTime(): DateTimeImmutable
+    public function getTime(): ?DateTimeImmutable
     {
         return $this->time;
     }

--- a/src/DTO/Delivery.php
+++ b/src/DTO/Delivery.php
@@ -49,8 +49,9 @@ class Delivery
      * @var DataMessageEvent[]
      */
     #[Serializer\Type('array<TomasKulhanek\CzechDataBox\DTO\DataMessageEvent>')]
-    #[Serializer\XmlList(entry: 'dmEvent', inline: false)]
+    #[Serializer\XmlList(entry: 'dmEvent', inline: false, namespace: 'https://isds.czechpoint.cz/v20')]
     #[Serializer\SerializedName('dmEvents')]
+    #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
     #[Assert\All([
         new Assert\Type(type: DataMessageEvent::class)
     ])]

--- a/src/DTO/MessageRecord.php
+++ b/src/DTO/MessageRecord.php
@@ -31,7 +31,7 @@ class MessageRecord
     #[Serializer\SerializedName('dmAttachmentSize')]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
     #[Assert\Positive()]
-    protected int $attachmentSize;
+    protected ?int $attachmentSize = null;
 
     #[Serializer\Type("DateTimeImmutable<'Y-m-d\\TH:i:s.uP','Europe/Prague'>")]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
@@ -79,12 +79,12 @@ class MessageRecord
         return $this;
     }
 
-    public function getAttachmentSize(): int
+    public function getAttachmentSize(): ?int
     {
         return $this->attachmentSize;
     }
 
-    public function setAttachmentSize(int $attachmentSize): MessageRecord
+    public function setAttachmentSize(?int $attachmentSize): MessageRecord
     {
         $this->attachmentSize = $attachmentSize;
         return $this;

--- a/src/DTO/PersonalOwnerInfo.php
+++ b/src/DTO/PersonalOwnerInfo.php
@@ -61,7 +61,7 @@ class PersonalOwnerInfo
     #[Serializer\SkipWhenEmpty]
     #[Serializer\Type('string')]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
-    #[Serializer\SerializedName('adStreet')]
+    #[Serializer\SerializedName('adDistrict')]
     protected ?string $adDistrict = null;
 
     #[Serializer\SkipWhenEmpty]

--- a/src/DTO/Request/DTInfo.php
+++ b/src/DTO/Request/DTInfo.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace TomasKulhanek\CzechDataBox\DTO\Request;
 
 use JMS\Serializer\Annotation as Serializer;
-use TomasKulhanek\CzechDataBox\Traits\DataBoxId;
 
 /**
  * Class DTInfo
@@ -14,5 +13,19 @@ use TomasKulhanek\CzechDataBox\Traits\DataBoxId;
 #[Serializer\XmlRoot(namespace: 'https://isds.czechpoint.cz/v20', name: 'DTInfo')]
 class DTInfo implements IRequest
 {
-    use DataBoxId;
+    #[Serializer\Type('string')]
+    #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
+    #[Serializer\SerializedName('dbId')]
+    protected string $dataBoxId;
+
+    public function getDataBoxId(): string
+    {
+        return $this->dataBoxId;
+    }
+
+    public function setDataBoxId(string $dataBoxId): self
+    {
+        $this->dataBoxId = $dataBoxId;
+        return $this;
+    }
 }

--- a/src/DTO/Response/CheckDataBox.php
+++ b/src/DTO/Response/CheckDataBox.php
@@ -8,7 +8,7 @@ use JMS\Serializer\Annotation as Serializer;
 use TomasKulhanek\CzechDataBox\Traits\DataBoxStatus;
 
 #[Serializer\XmlNamespace(uri: 'https://isds.czechpoint.cz/v20', prefix: 'p')]
-#[Serializer\XmlRoot(namespace: 'https://isds.czechpoint.cz/v20', name: 'FindDataBoxResponse')]
+#[Serializer\XmlRoot(namespace: 'https://isds.czechpoint.cz/v20', name: 'CheckDataBoxResponse')]
 class CheckDataBox extends IResponse
 {
     use DataBoxStatus;

--- a/src/DTO/ReturnedMessage.php
+++ b/src/DTO/ReturnedMessage.php
@@ -55,7 +55,7 @@ class ReturnedMessage
     #[Serializer\SerializedName('dmAttachmentSize')]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
     #[Assert\Positive]
-    protected int $attachmentSize;
+    protected ?int $attachmentSize = null;
 
     public function getType(): string
     {
@@ -123,12 +123,12 @@ class ReturnedMessage
         return $this;
     }
 
-    public function getAttachmentSize(): int
+    public function getAttachmentSize(): ?int
     {
         return $this->attachmentSize;
     }
 
-    public function setAttachmentSize(int $attachmentSize): ReturnedMessage
+    public function setAttachmentSize(?int $attachmentSize): ReturnedMessage
     {
         $this->attachmentSize = $attachmentSize;
         return $this;

--- a/src/DTO/ReturnedMessageEnvelope.php
+++ b/src/DTO/ReturnedMessageEnvelope.php
@@ -55,7 +55,7 @@ class ReturnedMessageEnvelope
     #[Serializer\SerializedName('dmAttachmentSize')]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
     #[Assert\Positive()]
-    protected int $attachmentSize;
+    protected ?int $attachmentSize = null;
 
     public function getType(): string
     {
@@ -123,12 +123,12 @@ class ReturnedMessageEnvelope
         return $this;
     }
 
-    public function getAttachmentSize(): int
+    public function getAttachmentSize(): ?int
     {
         return $this->attachmentSize;
     }
 
-    public function setAttachmentSize(int $attachmentSize): ReturnedMessageEnvelope
+    public function setAttachmentSize(?int $attachmentSize): ReturnedMessageEnvelope
     {
         $this->attachmentSize = $attachmentSize;
         return $this;

--- a/src/Traits/QTimestamp.php
+++ b/src/Traits/QTimestamp.php
@@ -11,5 +11,10 @@ trait QTimestamp
     #[Serializer\Type('string')]
     #[Serializer\XmlElement(cdata: false, namespace: 'https://isds.czechpoint.cz/v20')]
     #[Serializer\SerializedName('dmQTimestamp')]
-    protected string $qTimestamp;
+    protected ?string $qTimestamp = null;
+
+    public function getQTimestamp(): ?string
+    {
+        return $this->qTimestamp;
+    }
 }

--- a/tests/Unit/DtoXsdMappingTest.php
+++ b/tests/Unit/DtoXsdMappingTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasKulhanek\Tests\CzechDataBox\Unit;
+
+use PHPUnit\Framework\TestCase;
+use TomasKulhanek\CzechDataBox\DTO\DataBoxResult;
+use TomasKulhanek\CzechDataBox\DTO\Delivery;
+use TomasKulhanek\CzechDataBox\DTO\Request\DTInfo;
+use TomasKulhanek\Serializer\SerializerFactory;
+
+class DtoXsdMappingTest extends TestCase
+{
+    public function testDeliveryEventTimeIsDeserialized(): void
+    {
+        $serializer = SerializerFactory::create();
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<p:dmDelivery xmlns:p="https://isds.czechpoint.cz/v20">
+  <p:dmDm>
+    <p:dmID>1234567</p:dmID>
+  </p:dmDm>
+  <p:dmHash algorithm="SHA-256">abcdef</p:dmHash>
+  <p:dmQTimestamp>dGVzdA==</p:dmQTimestamp>
+  <p:dmEvents>
+    <p:dmEvent>
+      <p:dmEventTime>2026-06-26T08:30:00.000+02:00</p:dmEventTime>
+      <p:dmEventDescr>EV0: Podáno</p:dmEventDescr>
+    </p:dmEvent>
+  </p:dmEvents>
+</p:dmDelivery>
+XML;
+        $delivery = $serializer->deserialize($xml, Delivery::class, 'xml');
+        $events = $delivery->getEvents();
+        self::assertCount(1, $events);
+        self::assertNotNull($events[0]->getTime());
+        self::assertSame('2026-06-26T08:30:00+02:00', $events[0]->getTime()->format('c'));
+        self::assertSame('EV0: Podáno', $events[0]->getDescription());
+    }
+
+    public function testDtInfoRequestUsesLowercaseDbId(): void
+    {
+        $serializer = SerializerFactory::create();
+        $request = new DTInfo();
+        $request->setDataBoxId('abcdefg');
+        $xml = $serializer->serialize($request, 'xml');
+        self::assertStringContainsString('<dbId>abcdefg</dbId>', $xml);
+        self::assertStringNotContainsString('<dbID>', $xml);
+    }
+
+    public function testDataBoxResultMapsDbIdOvm(): void
+    {
+        $serializer = SerializerFactory::create();
+        $xml = <<<XML_WRAP
+<?xml version="1.0" encoding="UTF-8"?>
+<p:dbResult xmlns:p="https://isds.czechpoint.cz/v20">
+  <p:dbID>abcdefg</p:dbID>
+  <p:dbType>OVM</p:dbType>
+  <p:dbName>Testovací úřad</p:dbName>
+  <p:dbAddress>Testovací 1, Praha</p:dbAddress>
+  <p:dbBiDate xsi:nil="true" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+  <p:dbICO>12345678</p:dbICO>
+  <p:dbIdOVM>12345678</p:dbIdOVM>
+  <p:dbSendOptions>ALL</p:dbSendOptions>
+</p:dbResult>
+XML_WRAP;
+        $result = $serializer->deserialize($xml, DataBoxResult::class, 'xml');
+        self::assertSame('12345678', $result->getDataBoxIdOvm());
+        self::assertSame('OVM', $result->getDataBoxType());
+        self::assertSame('ALL', $result->getDataBoxSendOptions());
+    }
+}


### PR DESCRIPTION
## Souhrn

Opravy mapování DTO nalezené při auditu proti XSD z nového Provozního řádu ISDS (26. 06. 2026) — `dmBaseTypes.xsd` 3.10 a `dbTypes.xsd` 3.11.

> Stacked nad #33 (po jeho merge GitHub přesměruje base na `main`).

## Opravené chyby

| Oprava | Dopad |
|---|---|
| `DataMessageEvent`: překlep `dnEventTime` → `dmEventTime` (+ nullable dle XSD) | čas událostí doručenky se **nikdy nenaplnil** |
| `Delivery`: `dmEvents`/`dmEvent` bez ISDS namespace | seznam událostí z `GetDeliveryInfo` byl **vždy prázdný** |
| `PersonalOwnerInfo`: `$adDistrict` mapováno na `adStreet` (duplicitně) | okres se nenaplňoval |
| `DataBoxResult`: `dbEffectiveOVM` (bool) → `dbIdOVM` (string) dle `tdbResult2` | response ISDSSearch3 odpovídal starému ISDSSearch2 — ⚠️ **BC break**, getter přejmenován na `getDataBoxIdOvm()` |
| `Request/DTInfo`: `dbID` → `dbId` dle `tDTInfoInput` | XML je case-sensitive |
| `Response/CheckDataBox`: root `FindDataBoxResponse` → `CheckDataBoxResponse` | kosmetické |
| `dmAttachmentSize`, `dmQTimestamp` nullable (XSD `nillable="true"`) + getter `getQTimestamp()` | prevence „typed property not initialized" |

Ponechán `dmStatusRefNumber` v `DataMessageStatus` (v XSD `tStatus` neexistuje, ale je neškodný a vyžaduje ho interface `IResponseStatus`) — kandidát na odstranění v úklidovém PR.

## Testy

Nový `tests/Unit/DtoXsdMappingTest.php` ověřuje deserializaci událostí doručenky, serializaci `dbId` a mapování `dbIdOVM`. Celá sada: 19 testů, phpstan/rector/phpcs zelené.

🤖 Generated with [Claude Code](https://claude.com/claude-code)