### PR TITLE
docs: changelog for v6.0.0 and Operating Rules duties in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+Formát vychází z [Keep a Changelog](https://keepachangelog.com/cs/1.1.0/), verzování dle [SemVer](https://semver.org/lang/cs/).
+
+## [6.0.0] – zatím nevydáno
+
+Sjednocení knihovny s Provozním řádem ISDS platným od 26. 06. 2026 (WSDL 3.11). Podrobnosti v PR [#33](https://github.com/tomas-kulhanek/czech-data-box/pull/33), [#34](https://github.com/tomas-kulhanek/czech-data-box/pull/34), [#35](https://github.com/tomas-kulhanek/czech-data-box/pull/35), [#40](https://github.com/tomas-kulhanek/czech-data-box/pull/40), [#37](https://github.com/tomas-kulhanek/czech-data-box/pull/37), [#38](https://github.com/tomas-kulhanek/czech-data-box/pull/38) a [#39](https://github.com/tomas-kulhanek/czech-data-box/pull/39).
+
+### ⚠️ Breaking changes
+
+- **Endpointy**: výchozí domény změněny z `mojedatovaschranka.cz` / `czebox.cz` na **`datovka.gov.cz`** / **`datovka-test.gov.cz`**. Staré domény zůstávají funkční minimálně do 31. 12. 2027, knihovna je ale už nepoužívá.
+- **`Connector::findDataBox()` odstraněno** — nahrazeno `findDataBox2()` (operace `FindDataBox2`, struktury `OwnerInfoExt2` s `pnGivenNames`, `aifoIsds`, `dbIdOVM`, `dbUpperID` a RUIAN adresou). Stará operace není v dokumentaci ISDS od r. 2018.
+- **`Connector::findPersonalDataBox()` odstraněno** (zrušeno v ISDS 2018, nahrazeno FindDataBox2) včetně DTO `PersonalOwnerInfo`.
+- **`Connector::confirmDelivery()` odstraněno** — služba v ISDS neexistuje od verze rozhraní 2.33.
+- **`ServiceTypeEnum::SUPPLEMENTARY` odstraněno** (duplikát `ACCESS`, nikdy se nevolal).
+- **`DataBoxResult`**: `getDataBoxEffectiveOvm(): ?bool` → **`getDataBoxIdOvm(): ?string`** — odpověď `ISDSSearch3` odpovídá `tdbResult2`, kde `dbEffectiveOVM` neexistuje.
+- **`Envelope::getPublishOwnId()`** nově vrací `?PublishOwnId` (objekt s hodnotou a atributem `IdLevel`) místo `?bool`; setter dál přijímá i `bool`.
+- **Limit velikosti příloh snížen z 25 MiB na 20 MB** (limit běžné datové zprávy dle řádu); do součtu se nově počítají i přílohy `dmXMLContent`.
+- **`createMessage()` nově vyhazuje** `AttachmentCountOverflow` (více než 100 příloh, resp. 10 kontejnerových ZIP/ASiC) a `DisallowedAttachmentFormat` (přípona mimo whitelist vyhlášky č. 194/2009 Sb.).
+- **Nullabilita dle XSD**: `getAttachmentSize(): ?int` (`MessageRecord`, `ReturnedMessage`, `ReturnedMessageEnvelope`), `DataMessageEvent::getTime(): ?DateTimeImmutable`, `$qTimestamp` nullable.
+
+### Přidáno
+
+- **Nové operace dm_info**: `sentMessageEnvelopeDownload()`, `getMessageAuthor2()`, `eraseMessage()`, `getListOfErasedMessages()` + `pickUpAsyncResponse()`, `getListForNotifications()`, `registerForNotifications()`, `suspMessageReport()` (nahlášení podezřelé zprávy).
+- **Nové operace dm_operations**: `dummyOperation()` (keep-alive).
+- **Nové operace db_search**: `getConstants()`, `getDataBoxAddress()`.
+- **Nové operace db_access**: `getOwnerInfoFromLogin2()`, `getUserInfoFromLogin2()` (rozšířené údaje: `aifoIsds`, `isdsID`, `dbIdOVM`, RUIAN adresa).
+- **Velkoobjemové datové zprávy (VoDZ, do 100 MB)** přes SOAP 1.2 na endpointech `ws2[c].…/DS/vodz`: `uploadAttachment()`, `downloadAttachment()`, `createBigMessage()`, `authenticateBigMessage()`, `bigMessageDownload()`, `signedBigMessageDownload()`, `signedSentBigMessageDownload()`.
+- **Archivace**: `archiveIsdsDocument()` (přerazítkování ZFO) na `ws2[c].…/DS/arch`.
+- **Nové atributy DTO**: `specMessFlag` + `isSuspicious()` (podezřelá zpráva), `dmVODZ` + `isVodz()` a `attsNum` (rozpoznání VoDZ v seznamech), `PublishOwnId` s `IdLevel`.
+- **Nová pole DTO**: `pnLastNameAtBirth`, `caState`, `adDistrict`, `adAMCode`.
+- **`Utils\AllowedAttachmentFormats`** — whitelist 51 povolených přípon vč. kontejnerových formátů.
+
+### Opraveno
+
+- Události doručenky (`GetDeliveryInfo`) se nikdy nedeserializovaly — překlep `dnEventTime` → `dmEventTime` a chybějící namespace u `dmEvents`.
+- `PersonalOwnerInfo::$adDistrict` bylo mapováno na element `adStreet`.
+- `DTInfo` request posílal `dbID` místo `dbId` (XML je case-sensitive).
+- `Response\CheckDataBox` měl XML root `FindDataBoxResponse` místo `CheckDataBoxResponse`.
+- Duplicitní prázdný atribut `#[Assert\All()]` v `Delivery` shazoval phpstan.
+- Integrační test importoval neexistující třídu `Utils\MessageStatus`.
+
+### Migrace z 5.x
+
+1. `findDataBox(new FindDataBox())` → `findDataBox2(new FindDataBox2())`; místo `OwnerInfo` naplňte `OwnerInfoExt2` (jména přes `setGivenNames()` místo first/middle name).
+2. `findPersonalDataBox()` → `findDataBox2()` s vyplněnými osobními údaji.
+3. Volání `confirmDelivery()` odstraňte bez náhrady (služba v ISDS neexistuje).
+4. `getDataBoxEffectiveOvm()` → `getDataBoxIdOvm()` (identifikátor OVM z Rejstříku OVM, `?string`).
+5. `getPublishOwnId()` vrací objekt: booleovskou hodnotu čtěte přes `->getValue()`.
+6. Zprávy nad 20 MB odesílejte přes VoDZ (`uploadAttachment()` + `createBigMessage()`).
+7. Počítejte s novými výjimkami `AttachmentCountOverflow` a `DisallowedAttachmentFormat` u `createMessage()`.
+
+## [5.0.0] – 2024-05-24
+
+Viz [release notes](https://github.com/tomas-kulhanek/czech-data-box/releases/tag/v5.0.0). Starší verze viz [Releases](https://github.com/tomas-kulhanek/czech-data-box/releases).

--- a/README.md
+++ b/README.md
@@ -66,12 +66,26 @@ $serializer = \TomasKulhanek\Serializer\SerializerFactory::create();
 $guzzleProvider = \TomasKulhanek\CzechDataBox\Provider\GuzzleClientProvider::create();
 $connector = new \TomasKulhanek\CzechDataBox\Connector($serializer, $guzzleProvider);
 ```
+## Povinnosti aplikace dle Provozního řádu ISDS
+
+Knihovna řeší komunikaci s ISDS, ale některé povinnosti [Provozního řádu](https://datovka.gov.cz/info/cs/80.html) musí zajistit až vaše aplikace:
+
+- **Evidujte již stažené zprávy a stahujte jen nové** (kap. II.17 „Dodržování přiměřenosti"). Aplikace nesmí opakovaně stahovat celé seznamy a obsahy zpráv — použijte filtry `GetListOfReceivedMessages`/`GetListOfSentMessages` (od–do, stavy) a vlastní evidenci zpracovaných `dmID`.
+- **Lokální (desktopové) aplikace se smí přihlašovat pouze na manuální pokyn uživatele.** Serverové aplikace se mohou přihlašovat automatizovaně, ale jen v nezbytné frekvenci.
+- **Počítejte s omezením počtu dotazů.** Při překračování denních limitů ISDS nejprve zasílá systémovou zprávu, poté odpovědi zdržuje o 3 sekundy a souběžný požadavek ze stejného účtu odmítá. Nespouštějte paralelní požadavky pod jedním účtem a implementujte přiměřený retry.
+- **⚠ Přístupové údaje nesmí opustit zařízení pod plnou kontrolou uživatele.** Předání jména a hesla cloudové/webové aplikaci třetí strany je porušením § 9 odst. 2 zákona č. 300/2008 Sb. — Správce může takové údaje zneplatnit. Doporučená autentizace pro externí systémy je systémový certifikát (`LoginTypeEnum::SPIS_CERT`).
+- **Doručení přihlášením** (§ 17 odst. 3) způsobuje výhradně volání `GetListOfReceivedMessages` — ostatní operace doručení nezpůsobí.
+- **Údržba ISDS** probíhá zpravidla v pátek 0:00–1:00 (možná krátká nedostupnost); knihovna při HTTP 503 vyhazuje `SystemExclusion`.
+- **Zprávy nad 20 MB** odesílejte jako velkoobjemové (VoDZ, do 100 MB) přes `uploadAttachment()` + `createBigMessage()`; hromadné odeslání u VoDZ není podporováno.
+- Změny webových služeb oznamuje DIA zpravidla 2 měsíce předem na [stránce pro dodavatele](https://datovka.gov.cz/info/cs/74.html); dodavatelům aplikací se doporučuje [registrace do pracovního prostoru](https://registrace.poradnaisds.cz).
+
 ## Pomoc a řešní chyb
 
 V případě že potřebujete poradit, nebo při implementaci Vám třída zobrazuje chybu vytvořte prosím nové Issues.
 Základní pomoc je poskytována zcela zdarma pomocí Issues.
 
 ## Odkazy
+- Changelog knihovny - [CHANGELOG.md](CHANGELOG.md)
 - Produkční ISDS - https://www.datovka.gov.cz
 - Testovací ISDS - https://datovka-test.gov.cz
 - Provozní řád ISDS - https://datovka.gov.cz/info/cs/80.html


### PR DESCRIPTION
## Souhrn

Dokumentační tečka za sérií PR k Provoznímu řádu ISDS 26. 06. 2026 (#33–#39, #40):

- **CHANGELOG.md** (nový) — kompletní přehled verze 6.0.0: breaking changes, nové operace (vč. VoDZ a archivace), opravy a **migrační průvodce z 5.x** v 7 krocích.
- **README** — nová sekce „Povinnosti aplikace dle Provozního řádu ISDS": evidence stažených zpráv (kap. II.17), rate-limiting (odklad 3 s), přihlašování lokálních aplikací jen na pokyn uživatele, varování § 9 odst. 2 (předávání přístupových údajů) s doporučením systémového certifikátu, doručení přihlášením, servisní okno, VoDZ pro zprávy nad 20 MB, registrace dodavatelů. Přidán odkaz na changelog.

Bez změn kódu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)